### PR TITLE
Remove null orcid to allow new Zenodo DOI

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -7,8 +7,7 @@
     },
     {
       "affiliation": "",
-      "name": "Levin, David",
-      "orcid": ""
+      "name": "Levin, David"
     }
   ],
   "keywords": [


### PR DESCRIPTION
@lwasser This pull request removes the null orcid for David Levin to allow Zenodo to assign DOI for new release of the package.